### PR TITLE
Fixed the docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ def deps do
 end
 ```
 
-See the [getting started guide](hexdocs.pm/ash_cloak) on hex!
+See the [getting started guide](https://hexdocs.pm/ash_cloak) on hex!


### PR DESCRIPTION
Currently the docs link is considered a relative link and tries to find hex.pm on GitHub. This PR fixes that.