### PR TITLE
fix: run encrypt on before_action

### DIFF
--- a/lib/ash_cloak/changes/encrypt.ex
+++ b/lib/ash_cloak/changes/encrypt.ex
@@ -3,28 +3,30 @@ defmodule AshCloak.Changes.Encrypt do
   use Ash.Resource.Change
 
   def change(changeset, opts, _) do
-    attribute = opts[:field]
+    Ash.Changeset.before_action(changeset, fn changeset ->
+      attribute = opts[:field]
 
-    case Ash.Changeset.fetch_argument(changeset, attribute) do
-      {:ok, value} ->
-        vault = AshCloak.Info.cloak_vault!(changeset.resource)
-        encryption_target = String.to_existing_atom("encrypted_#{attribute}")
+      case Ash.Changeset.fetch_argument(changeset, attribute) do
+        {:ok, value} ->
+          vault = AshCloak.Info.cloak_vault!(changeset.resource)
+          encryption_target = String.to_existing_atom("encrypted_#{attribute}")
 
-        encrypted_value =
-          value
-          |> :erlang.term_to_binary()
-          |> vault.encrypt!()
-          |> Base.encode64()
+          encrypted_value =
+            value
+            |> :erlang.term_to_binary()
+            |> vault.encrypt!()
+            |> Base.encode64()
 
-        changeset
-        |> Ash.Changeset.force_change_attribute(encryption_target, encrypted_value)
-        |> Ash.Changeset.delete_argument(attribute)
-        |> Map.update!(:params, fn params ->
-          Map.drop(params, [attribute, to_string(attribute)])
-        end)
+          changeset
+          |> Ash.Changeset.force_change_attribute(encryption_target, encrypted_value)
+          |> Ash.Changeset.delete_argument(attribute)
+          |> Map.update!(:params, fn params ->
+            Map.drop(params, [attribute, to_string(attribute)])
+          end)
 
-      :error ->
-        changeset
-    end
+        :error ->
+          changeset
+      end
+    end)
   end
 end

--- a/test/ash_cloak_test.exs
+++ b/test/ash_cloak_test.exs
@@ -39,4 +39,32 @@ defmodule AshCloakTest do
     # only for fields that are being decrypted
     refute_received {:decrypting, _, _, _, _}
   end
+
+  test "encrypt after action change" do
+    encrypted =
+      AshCloak.Test.Resource
+      |> Ash.Changeset.for_create(:change_before_encrypt, %{
+        not_encrypted: "plain",
+        encrypted_always_loaded: %{hello: :world}
+      })
+      |> Ash.Changeset.set_context(%{foo: :bar})
+      |> Ash.create!()
+
+    assert decode(encrypted.encrypted_encrypted) == 13
+  end
+
+  test "it encrypt by set_argument directly" do
+    encrypted =
+      AshCloak.Test.Resource
+      |> Ash.Changeset.new()
+      |> Ash.Changeset.set_argument(:encrypted, 14)
+      |> Ash.Changeset.for_create(:create, %{
+        not_encrypted: "plain",
+        encrypted_always_loaded: %{hello: :world}
+      })
+      |> Ash.Changeset.set_context(%{foo: :bar})
+      |> Ash.create!()
+
+    assert decode(encrypted.encrypted_encrypted) == 14
+  end
 end

--- a/test/support/change.ex
+++ b/test/support/change.ex
@@ -1,4 +1,5 @@
 defmodule AshCloak.Test.Change do
+  @moduledoc false
   use Ash.Resource.Change
 
   def change(changeset, _opts, _) do

--- a/test/support/change.ex
+++ b/test/support/change.ex
@@ -1,0 +1,7 @@
+defmodule AshCloak.Test.Change do
+  use Ash.Resource.Change
+
+  def change(changeset, _opts, _) do
+    changeset |> Ash.Changeset.set_argument(:encrypted, 13)
+  end
+end

--- a/test/support/resource.ex
+++ b/test/support/resource.ex
@@ -13,6 +13,11 @@ defmodule AshCloak.Test.Resource do
   @attributes [:encrypted, :encrypted_always_loaded, :not_encrypted]
   actions do
     defaults([:read, :destroy, create: @attributes, update: @attributes])
+
+    create :change_before_encrypt do
+      accept(@attributes)
+      change(AshCloak.Test.Change)
+    end
   end
 
   cloak do


### PR DESCRIPTION
This PR addresses an issue where using custom changes or the `set_argument` function on a changeset was ignored by `AshCloak.Changes.Encrypt`.

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
