### PR TITLE
Make AshCloak.encrypt_and_set raise a specific error.

### DIFF
--- a/lib/ash_cloak.ex
+++ b/lib/ash_cloak.ex
@@ -45,6 +45,8 @@ defmodule AshCloak do
 
   If the changeset is pending (i.e not currently running the action), then it is added as a before_action hook.
   Otherwise, it is run immediately
+  
+  Raises an error if the attribute is not configured for encryption.
   """
   @spec encrypt_and_set(Ash.Changeset.t(), attr :: atom, term :: term) :: Ash.Changeset.t()
   def encrypt_and_set(changeset, key, value) do
@@ -55,7 +57,8 @@ defmodule AshCloak do
         do_encrypt_and_set(changeset, key, value)
       end
     else
-      raise "Attempted to encrypt and set attribute #{inspect(key)} for resource #{inspect(changeset.resource)}, but it is not configured for encryption."
+      message = "Attempted to encrypt and set attribute #{inspect(key)} for resource #{inspect(changeset.resource)}, but it is not configured for encryption."
+      raise Ash.Error.Changes.InvalidAttribute, field: key, message: message
     end
   end
 

--- a/lib/ash_cloak.ex
+++ b/lib/ash_cloak.ex
@@ -45,8 +45,8 @@ defmodule AshCloak do
 
   If the changeset is pending (i.e not currently running the action), then it is added as a before_action hook.
   Otherwise, it is run immediately
-  
-  Raises an error if the attribute is not configured for encryption.
+
+  Raises AshCloak.Errors.NoSuchEncryptedAttribute if the attribute is not configured for encryption.
   """
   @spec encrypt_and_set(Ash.Changeset.t(), attr :: atom, term :: term) :: Ash.Changeset.t()
   def encrypt_and_set(changeset, key, value) do
@@ -57,8 +57,7 @@ defmodule AshCloak do
         do_encrypt_and_set(changeset, key, value)
       end
     else
-      message = "Attempted to encrypt and set attribute #{inspect(key)} for resource #{inspect(changeset.resource)}, but it is not configured for encryption."
-      raise Ash.Error.Changes.InvalidAttribute, field: key, message: message
+      raise AshCloak.Errors.NoSuchEncryptedAttribute, key: key, resource: changeset.resource
     end
   end
 

--- a/lib/ash_cloak/errors/no_such_encrypted_attribute.ex
+++ b/lib/ash_cloak/errors/no_such_encrypted_attribute.ex
@@ -1,0 +1,19 @@
+defmodule AshCloak.Errors.NoSuchEncryptedAttribute do
+  @moduledoc """
+  An error raised when attempting to decrypt an attribute that is not encrypted.
+  """
+
+  use Splode.Error, fields: [:key, :resource], class: :invalid
+  
+  def message(error) do
+    """
+    Attempted to encrypt and set attribute#{for_key(error)}#{for_resource(error)}, but it is not configured for encryption.}
+    """
+  end
+
+  defp for_key(%{key: key}) when not is_nil(key), do: " for #{key}"
+  defp for_key(_), do: ""
+
+  defp for_resource(%{resource: resource}) when not is_nil(resource), do: " for #{resource}"
+  defp for_resource(_), do: ""
+end

--- a/test/ash_cloak_test.exs
+++ b/test/ash_cloak_test.exs
@@ -191,7 +191,7 @@ defmodule AshCloakTest do
     assert decode(changeset.encrypted_encrypted) == 16
 
     # Test with invalid attribute
-    assert_raise Ash.Error.Changes.InvalidAttribute, fn ->
+    assert_raise AshCloak.Errors.NoSuchEncryptedAttribute, fn ->
       AshCloak.Test.Resource
       |> Ash.Changeset.for_create(:create, %{})
       |> AshCloak.encrypt_and_set(:non_existent, "value")


### PR DESCRIPTION
### Contributor notes

`AshCloak.encrypt_and_set/3` now raises a specific error `Ash.Error.Changes.InvalidAttribute` if the attribute is not configured for encryption.

Tests for `AshCloak.encrypt_and_set/3`  added.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
