### PR TITLE
Apply default of attrs only for create actions

### DIFF
--- a/lib/ash_cloak/transformers/set_up_encryption.ex
+++ b/lib/ash_cloak/transformers/set_up_encryption.ex
@@ -88,11 +88,14 @@ defmodule AshCloak.Transformers.SetupEncryption do
     |> Enum.reduce_while({:ok, dsl}, fn action, {:ok, dsl} ->
       new_accept = action.accept -- [attr.name]
 
+      opts =
+        case action.type do
+          :create -> [constraints: attr.constraints, default: attr.default]
+          _ -> [constraints: attr.constraints]
+        end
+
       with {:ok, argument} <-
-             Ash.Resource.Builder.build_action_argument(attr.name, attr.type,
-               constraints: attr.constraints,
-               default: attr.default
-             ),
+             Ash.Resource.Builder.build_action_argument(attr.name, attr.type, opts),
            {:ok, change} <-
              Ash.Resource.Builder.build_action_change(
                {AshCloak.Changes.Encrypt, field: attr.name}

--- a/test/ash_cloak_test.exs
+++ b/test/ash_cloak_test.exs
@@ -176,6 +176,23 @@ defmodule AshCloakTest do
     assert decode(encrypted.encrypted_encrypted_with_default) == 42
   end
 
+  test "it doesn't update not accepted encrypted fields with default value" do
+    encrypted =
+      AshCloak.Test.Resource
+      |> Ash.Changeset.for_create(:create, %{encrypted_with_default: 1})
+      |> Ash.create!()
+
+    assert decode(encrypted.encrypted_encrypted_with_default) == 1
+
+    updated_encrypted =
+      encrypted
+      |> Ash.Changeset.for_update(:update_not_encrypted, %{not_encrypted: "plain"})
+      |> Ash.update!()
+
+    assert updated_encrypted.not_encrypted == "plain"
+    assert decode(updated_encrypted.encrypted_encrypted_with_default) == 1
+  end
+
   test "encrypt_and_set encrypts and sets values correctly" do
     # Test with pending changeset
     pending_changeset =

--- a/test/support/resource.ex
+++ b/test/support/resource.ex
@@ -22,6 +22,10 @@ defmodule AshCloak.Test.Resource do
     create :change_without_accept do
       change(AshCloak.Test.Change)
     end
+
+    update :update_not_encrypted do
+      accept([:not_encrypted])
+    end
   end
 
   cloak do


### PR DESCRIPTION
This PR fixes a bug introduced in #80. The default option was supposed to apply only to create actions but was mistakenly applied to other actions as well.

For example, in update actions, unintended updates occurred where values were set to their default values, even when they shouldn’t have been.

Apologies for not catching this issue earlier in the previous implementation. 🙏

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
