### PR TITLE
fix(#115): fix the missing attribute name when the passed attribute does not exist

### DIFF
--- a/lib/ash_cloak/transformers/set_up_encryption.ex
+++ b/lib/ash_cloak/transformers/set_up_encryption.ex
@@ -13,7 +13,7 @@ defmodule AshCloak.Transformers.SetupEncryption do
       if !attribute do
         raise Spark.Error.DslError,
           module: module,
-          message: "No attribute called #{inspect(attribute)} found",
+          message: "No attribute called #{inspect(attr)} found",
           path: [:cloak, :attributes]
       end
 

--- a/priv/bad_fixtures/bad_resource.ex
+++ b/priv/bad_fixtures/bad_resource.ex
@@ -1,0 +1,28 @@
+defmodule AshCloak.Test.BadResource do
+  @moduledoc false
+
+  use Ash.Resource,
+    domain: AshCloak.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshCloak]
+
+  actions do
+    defaults([:read, :destroy, create: :*, update: :*])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute :some_secret, :string do
+      allow_nil?(false)
+      public?(false)
+      sensitive?(true)
+    end
+  end
+
+  cloak do
+    vault AshCloak.Test.Vault
+
+    attributes [:huuge_typo_in_some_secret_lol]
+  end
+end

--- a/test/ash_cloak/set_up_encryption_test.exs
+++ b/test/ash_cloak/set_up_encryption_test.exs
@@ -1,0 +1,20 @@
+defmodule AshCloak.SetUpEncryptionTest do
+  @moduledoc false
+
+  @bad_fixtures_dir Application.app_dir(:ash_cloak, "priv/bad_fixtures")
+  @bad_resource_file Path.join([@bad_fixtures_dir, "bad_resource.ex"])
+
+  @external_resource @bad_resource_file
+
+  use ExUnit.Case
+
+  test "outputs the invalid attribute in the error message" do
+    %Spark.Error.DslError{message: message} =
+      assert_raise Spark.Error.DslError,
+                   fn ->
+                     Code.eval_file(@bad_resource_file)
+                   end
+
+    assert message =~ "No attribute called :huuge_typo_in_some_secret_lol"
+  end
+end


### PR DESCRIPTION
Fixes the missing attribute name in the logged output.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
