### PR TITLE
chore: add test to demonstrate encrypted attributes accepts behavior

### DIFF
--- a/test/ash_cloak_test.exs
+++ b/test/ash_cloak_test.exs
@@ -225,7 +225,7 @@ defmodule AshCloakTest do
     end
   end
 
-  test "does not automatically add encrypted attributes to accepts list" do
+  test "does not automatically allow passing encrypted fields as action input" do
     assert_raise Ash.Error.Invalid, ~r/No such input `encrypted`/, fn ->
       AshCloak.Test.Resource
       |> Ash.Changeset.for_create(:change_without_accept, %{encrypted: 42})


### PR DESCRIPTION
This PR demonstrates an issue where AshCloak automatically adds encrypted attributes to the `accepts` list of all actions.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
