### PR TITLE
feat: add vault_selector DSL option for runtime vault selection

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -2,13 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-spark_locals_without_parens = [
-  attributes: 1,
-  decrypt_by_default: 1,
-  on_decrypt: 1,
-  vault: 1,
-  vault_selector: 1
-]
+spark_locals_without_parens = [attributes: 1, decrypt_by_default: 1, on_decrypt: 1, vault: 1]
 
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -2,7 +2,13 @@
 #
 # SPDX-License-Identifier: MIT
 
-spark_locals_without_parens = [attributes: 1, decrypt_by_default: 1, on_decrypt: 1, vault: 1]
+spark_locals_without_parens = [
+  attributes: 1,
+  decrypt_by_default: 1,
+  on_decrypt: 1,
+  vault: 1,
+  vault_selector: 1
+]
 
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],

--- a/documentation/dsls/DSL-AshCloak.md
+++ b/documentation/dsls/DSL-AshCloak.md
@@ -20,11 +20,10 @@ Encrypt attributes of a resource
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`vault`](#cloak-vault){: #cloak-vault .spark-required} | `module` |  | The vault to use to encrypt & decrypt the value |
+| [`vault`](#cloak-vault){: #cloak-vault .spark-required} | `module \| (any, any -> any) \| mfa` |  | The vault to use to encrypt & decrypt the value. Accepts a module implementing `Cloak.Vault`, a `fun/2` of the form `(resource_module, context) -> vault_module`, or an MFA tuple. When a function or MFA is given, it is called at every encrypt and decrypt operation and its return value is used as the vault module. |
 | [`attributes`](#cloak-attributes){: #cloak-attributes } | `atom \| list(atom)` | `[]` | The attribute or attributes to encrypt. The attribute will be renamed to `encrypted_{attribute}`, and a calculation with the same name will be added. |
 | [`decrypt_by_default`](#cloak-decrypt_by_default){: #cloak-decrypt_by_default } | `atom \| list(atom)` | `[]` | A list of attributes that should be decrypted (their calculation should be loaded) by default. |
 | [`on_decrypt`](#cloak-on_decrypt){: #cloak-on_decrypt } | `(any, any, any, any -> any) \| mfa` |  | A function to call when decrypting any value. Takes the resource, field, records, and calculation context. Must return `:ok` or `{:error, error}` |
-| [`vault_selector`](#cloak-vault_selector){: #cloak-vault_selector } | `(any, any -> any) \| mfa` |  | An optional function `(resource_module, context) -> vault_module` called at encrypt and decrypt time to select the vault. When present, its return value takes precedence over the statically configured `vault`. The returned module must implement `encrypt!/1` and `decrypt!/1`. Both `%Ash.Resource.Change.Context{}` and `%Ash.Resource.Calculation.Context{}` may be passed as `context` depending on the call site. |
 
 
 

--- a/documentation/dsls/DSL-AshCloak.md
+++ b/documentation/dsls/DSL-AshCloak.md
@@ -24,6 +24,7 @@ Encrypt attributes of a resource
 | [`attributes`](#cloak-attributes){: #cloak-attributes } | `atom \| list(atom)` | `[]` | The attribute or attributes to encrypt. The attribute will be renamed to `encrypted_{attribute}`, and a calculation with the same name will be added. |
 | [`decrypt_by_default`](#cloak-decrypt_by_default){: #cloak-decrypt_by_default } | `atom \| list(atom)` | `[]` | A list of attributes that should be decrypted (their calculation should be loaded) by default. |
 | [`on_decrypt`](#cloak-on_decrypt){: #cloak-on_decrypt } | `(any, any, any, any -> any) \| mfa` |  | A function to call when decrypting any value. Takes the resource, field, records, and calculation context. Must return `:ok` or `{:error, error}` |
+| [`vault_selector`](#cloak-vault_selector){: #cloak-vault_selector } | `(any, any -> any) \| mfa` |  | An optional function `(resource_module, context) -> vault_module` called at encrypt and decrypt time to select the vault. When present, its return value takes precedence over the statically configured `vault`. The returned module must implement `encrypt!/1` and `decrypt!/1`. Both `%Ash.Resource.Change.Context{}` and `%Ash.Resource.Calculation.Context{}` may be passed as `context` depending on the call site. |
 
 
 

--- a/lib/ash_cloak.ex
+++ b/lib/ash_cloak.ex
@@ -38,6 +38,11 @@ defmodule AshCloak do
         type: {:or, [{:fun, 4}, :mfa]},
         doc:
           "A function to call when decrypting any value. Takes the resource, field, records, and calculation context. Must return `:ok` or `{:error, error}`"
+      ],
+      vault_selector: [
+        type: {:or, [{:fun, 2}, :mfa]},
+        doc:
+          "An optional function `(resource_module, context) -> vault_module` called at encrypt and decrypt time to select the vault. When present, its return value takes precedence over the statically configured `vault`. The returned module must implement `encrypt!/1` and `decrypt!/1`. Both `%Ash.Resource.Change.Context{}` and `%Ash.Resource.Calculation.Context{}` may be passed as `context` depending on the call site."
       ]
     ]
   }
@@ -53,12 +58,12 @@ defmodule AshCloak do
   Raises AshCloak.Errors.NoSuchEncryptedAttribute if the attribute is not configured for encryption.
   """
   @spec encrypt_and_set(Ash.Changeset.t(), attr :: atom, term :: term) :: Ash.Changeset.t()
-  def encrypt_and_set(changeset, key, value) do
+  def encrypt_and_set(changeset, key, value, context \\ nil) do
     if key in AshCloak.Info.cloak_attributes!(changeset.resource) do
       if changeset.phase == :pending do
-        Ash.Changeset.before_action(changeset, &do_encrypt_and_set(&1, key, value))
+        Ash.Changeset.before_action(changeset, &do_encrypt_and_set(&1, key, value, context))
       else
-        do_encrypt_and_set(changeset, key, value)
+        do_encrypt_and_set(changeset, key, value, context)
       end
     else
       raise AshCloak.Errors.NoSuchEncryptedAttribute, key: key, resource: changeset.resource
@@ -66,8 +71,22 @@ defmodule AshCloak do
   end
 
   @doc false
-  def do_encrypt(resource, value) do
-    vault = AshCloak.Info.cloak_vault!(resource)
+  def resolve_vault(resource, context) do
+    case AshCloak.Info.cloak_vault_selector(resource) do
+      {:ok, {m, f, a}} when not is_nil(context) ->
+        apply(m, f, [resource, context] ++ List.wrap(a))
+
+      {:ok, fun} when is_function(fun, 2) and not is_nil(context) ->
+        fun.(resource, context)
+
+      _ ->
+        AshCloak.Info.cloak_vault!(resource)
+    end
+  end
+
+  @doc false
+  def do_encrypt(resource, value, context \\ nil) do
+    vault = resolve_vault(resource, context)
 
     value
     |> :erlang.term_to_binary()
@@ -75,8 +94,8 @@ defmodule AshCloak do
     |> Base.encode64()
   end
 
-  defp do_encrypt_and_set(changeset, key, value) do
-    encrypted_value = do_encrypt(changeset.resource, value)
+  defp do_encrypt_and_set(changeset, key, value, context) do
+    encrypted_value = do_encrypt(changeset.resource, value, context)
     encryption_target = String.to_existing_atom("encrypted_#{key}")
 
     changeset

--- a/lib/ash_cloak.ex
+++ b/lib/ash_cloak.ex
@@ -18,8 +18,9 @@ defmodule AshCloak do
     describe: "Encrypt attributes of a resource",
     schema: [
       vault: [
-        type: {:behaviour, Cloak.Vault},
-        doc: "The vault to use to encrypt & decrypt the value",
+        type: {:or, [{:behaviour, Cloak.Vault}, {:fun, 2}, :mfa]},
+        doc:
+          "The vault to use to encrypt & decrypt the value. Accepts a module implementing `Cloak.Vault`, a `fun/2` of the form `(resource_module, context) -> vault_module`, or an MFA tuple. When a function or MFA is given, it is called at every encrypt and decrypt operation and its return value is used as the vault module.",
         required: true
       ],
       attributes: [
@@ -38,11 +39,6 @@ defmodule AshCloak do
         type: {:or, [{:fun, 4}, :mfa]},
         doc:
           "A function to call when decrypting any value. Takes the resource, field, records, and calculation context. Must return `:ok` or `{:error, error}`"
-      ],
-      vault_selector: [
-        type: {:or, [{:fun, 2}, :mfa]},
-        doc:
-          "An optional function `(resource_module, context) -> vault_module` called at encrypt and decrypt time to select the vault. When present, its return value takes precedence over the statically configured `vault`. The returned module must implement `encrypt!/1` and `decrypt!/1`. Both `%Ash.Resource.Change.Context{}` and `%Ash.Resource.Calculation.Context{}` may be passed as `context` depending on the call site."
       ]
     ]
   }
@@ -72,15 +68,15 @@ defmodule AshCloak do
 
   @doc false
   def resolve_vault(resource, context) do
-    case AshCloak.Info.cloak_vault_selector(resource) do
-      {:ok, {m, f, a}} when not is_nil(context) ->
-        apply(m, f, [resource, context] ++ List.wrap(a))
+    case AshCloak.Info.cloak_vault!(resource) do
+      {m, f, a} ->
+        apply(m, f, [resource, context | List.wrap(a)])
 
-      {:ok, fun} when is_function(fun, 2) and not is_nil(context) ->
+      fun when is_function(fun, 2) ->
         fun.(resource, context)
 
-      _ ->
-        AshCloak.Info.cloak_vault!(resource)
+      vault ->
+        vault
     end
   end
 

--- a/lib/ash_cloak/calculations/decrypt.ex
+++ b/lib/ash_cloak/calculations/decrypt.ex
@@ -9,7 +9,7 @@ defmodule AshCloak.Calculations.Decrypt do
   def load(_, opts, _), do: [opts[:field]]
 
   def calculate([%resource{} | _] = records, opts, context) do
-    vault = AshCloak.Info.cloak_vault!(resource)
+    vault = AshCloak.resolve_vault(resource, context)
     plain_field = opts[:plain_field]
 
     case approve_decrypt(resource, records, plain_field, context) do

--- a/lib/ash_cloak/changes/encrypt.ex
+++ b/lib/ash_cloak/changes/encrypt.ex
@@ -6,13 +6,16 @@ defmodule AshCloak.Changes.Encrypt do
   @moduledoc "Takes an argument, and encrypts it into an attribute called `encrypted_{attribute}`"
   use Ash.Resource.Change
 
-  def change(changeset, opts, _) do
+  def change(changeset, opts, context) do
     Ash.Changeset.before_action(changeset, fn changeset ->
       attribute = opts[:field]
+      # Refresh source_context from the changeset at hook-run time, not at change/3 call time.
+      # for_create/for_update runs changes immediately, before callers can set_context.
+      current_context = %{context | source_context: changeset.context}
 
       case Ash.Changeset.fetch_argument(changeset, attribute) do
         {:ok, value} ->
-          AshCloak.encrypt_and_set(changeset, attribute, value)
+          AshCloak.encrypt_and_set(changeset, attribute, value, current_context)
 
         :error ->
           changeset
@@ -20,13 +23,14 @@ defmodule AshCloak.Changes.Encrypt do
     end)
   end
 
-  def atomic(changeset, opts, _) do
+  def atomic(changeset, opts, context) do
     attribute = opts[:field]
+    current_context = %{context | source_context: changeset.context}
 
     case Ash.Changeset.fetch_argument(changeset, attribute) do
       {:ok, value} ->
         encryption_target = String.to_existing_atom("encrypted_#{attribute}")
-        {:atomic, %{encryption_target => AshCloak.do_encrypt(changeset.resource, value)}}
+        {:atomic, %{encryption_target => AshCloak.do_encrypt(changeset.resource, value, current_context)}}
 
       :error ->
         {:ok, changeset}

--- a/lib/ash_cloak/changes/encrypt.ex
+++ b/lib/ash_cloak/changes/encrypt.ex
@@ -30,7 +30,9 @@ defmodule AshCloak.Changes.Encrypt do
     case Ash.Changeset.fetch_argument(changeset, attribute) do
       {:ok, value} ->
         encryption_target = String.to_existing_atom("encrypted_#{attribute}")
-        {:atomic, %{encryption_target => AshCloak.do_encrypt(changeset.resource, value, current_context)}}
+
+        {:atomic,
+         %{encryption_target => AshCloak.do_encrypt(changeset.resource, value, current_context)}}
 
       :error ->
         {:ok, changeset}

--- a/test/ash_cloak/vault_selector_test.exs
+++ b/test/ash_cloak/vault_selector_test.exs
@@ -18,7 +18,7 @@ defmodule AshCloak.VaultSelectorTest do
     end
   end
 
-  describe "vault_selector (MFA form)" do
+  describe "vault MFA selector" do
     test "uses static vault when source_context has no test_vault key" do
       record =
         AshCloak.Test.ResourceWithSelector
@@ -127,7 +127,7 @@ defmodule AshCloak.VaultSelectorTest do
     end
   end
 
-  describe "encrypt_and_set with vault_selector" do
+  describe "encrypt_and_set with dynamic vault" do
     test "encrypt_and_set without Ash action context falls back to static vault" do
       record =
         AshCloak.Test.ResourceWithSelector

--- a/test/ash_cloak/vault_selector_test.exs
+++ b/test/ash_cloak/vault_selector_test.exs
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: 2024 ash_cloak contributors <https://github.com/ash-project/ash_cloak/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshCloak.VaultSelectorTest do
+  use ExUnit.Case, async: true
+
+  require Ash.Query
+
+  # Returns :default or :alt based on which vault's ciphertext prefix is present
+  defp raw_vault_prefix(record, field) do
+    raw = Map.get(record, :"encrypted_#{field}")
+    decoded = Base.decode64!(raw)
+
+    cond do
+      String.starts_with?(decoded, "alt_encrypted ") -> :alt
+      String.starts_with?(decoded, "encrypted ") -> :default
+    end
+  end
+
+  describe "vault_selector (MFA form)" do
+    test "uses static vault when source_context has no test_vault key" do
+      record =
+        AshCloak.Test.ResourceWithSelector
+        |> Ash.Changeset.for_create(:create, %{encrypted: 42})
+        |> Ash.create!()
+
+      assert raw_vault_prefix(record, :encrypted) == :default
+    end
+
+    test "uses alt vault when source_context has test_vault: :alt" do
+      record =
+        AshCloak.Test.ResourceWithSelector
+        |> Ash.Changeset.for_create(:create, %{encrypted: 42})
+        |> Ash.Changeset.set_context(%{test_vault: :alt})
+        |> Ash.create!()
+
+      assert raw_vault_prefix(record, :encrypted) == :alt
+    end
+
+    test "update action uses vault selector" do
+      record =
+        AshCloak.Test.ResourceWithSelector
+        |> Ash.Changeset.for_create(:create, %{encrypted: 1})
+        |> Ash.create!()
+
+      updated =
+        record
+        |> Ash.Changeset.for_update(:update, %{encrypted: 2})
+        |> Ash.Changeset.set_context(%{test_vault: :alt})
+        |> Ash.update!()
+
+      assert raw_vault_prefix(updated, :encrypted) == :alt
+    end
+
+    test "atomic bulk update uses vault selector" do
+      record =
+        AshCloak.Test.ResourceWithSelector
+        |> Ash.Changeset.for_create(:create, %{encrypted: 1})
+        |> Ash.create!()
+
+      %Ash.BulkResult{records: [updated]} =
+        AshCloak.Test.ResourceWithSelector
+        |> Ash.Query.filter(id == ^record.id)
+        |> Ash.bulk_update!(
+          :update,
+          %{encrypted: 2},
+          return_records?: true,
+          context: %{test_vault: :alt}
+        )
+
+      assert raw_vault_prefix(updated, :encrypted) == :alt
+    end
+
+    test "decrypt uses vault selector to choose correct vault" do
+      record =
+        AshCloak.Test.ResourceWithSelector
+        |> Ash.Changeset.for_create(:create, %{encrypted: 99})
+        |> Ash.Changeset.set_context(%{test_vault: :alt})
+        |> Ash.create!()
+
+      assert raw_vault_prefix(record, :encrypted) == :alt
+
+      loaded = Ash.load!(record, [:encrypted], context: %{test_vault: :alt})
+      assert loaded.encrypted == 99
+    end
+
+    test "different contexts produce ciphertext decryptable only by their respective vault" do
+      default_record =
+        AshCloak.Test.ResourceWithSelector
+        |> Ash.Changeset.for_create(:create, %{encrypted: 10})
+        |> Ash.create!()
+
+      alt_record =
+        AshCloak.Test.ResourceWithSelector
+        |> Ash.Changeset.for_create(:create, %{encrypted: 20})
+        |> Ash.Changeset.set_context(%{test_vault: :alt})
+        |> Ash.create!()
+
+      assert raw_vault_prefix(default_record, :encrypted) == :default
+      assert raw_vault_prefix(alt_record, :encrypted) == :alt
+
+      assert Ash.load!(default_record, [:encrypted]).encrypted == 10
+      assert Ash.load!(alt_record, [:encrypted], context: %{test_vault: :alt}).encrypted == 20
+    end
+
+    test "MFA dispatch: apply(m, f, [resource, context] ++ a) is invoked" do
+      # ResourceWithSelector uses {AshCloak.Test.VaultSelector, :select, []}
+      # Verify the MFA path executes correctly by confirming alt vault is selected
+      # when source_context carries the expected key
+      record =
+        AshCloak.Test.ResourceWithSelector
+        |> Ash.Changeset.for_create(:create, %{encrypted: 55})
+        |> Ash.Changeset.set_context(%{test_vault: :alt})
+        |> Ash.create!()
+
+      assert raw_vault_prefix(record, :encrypted) == :alt
+    end
+
+    test "MFA dispatch falls back to static vault without matching source_context" do
+      record =
+        AshCloak.Test.ResourceWithSelector
+        |> Ash.Changeset.for_create(:create, %{encrypted: 55})
+        |> Ash.create!()
+
+      assert raw_vault_prefix(record, :encrypted) == :default
+    end
+  end
+
+  describe "encrypt_and_set with vault_selector" do
+    test "encrypt_and_set without Ash action context falls back to static vault" do
+      record =
+        AshCloak.Test.ResourceWithSelector
+        |> Ash.Changeset.for_create(:create, %{})
+        |> AshCloak.encrypt_and_set(:encrypted, 77)
+        |> Ash.create!()
+
+      assert raw_vault_prefix(record, :encrypted) == :default
+    end
+  end
+end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -8,5 +8,6 @@ defmodule AshCloak.Test.Domain do
 
   resources do
     resource(AshCloak.Test.Resource)
+    resource(AshCloak.Test.ResourceWithSelector)
   end
 end

--- a/test/support/resource_with_selector.ex
+++ b/test/support/resource_with_selector.ex
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2024 ash_cloak contributors <https://github.com/ash-project/ash_cloak/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshCloak.Test.VaultSelector do
+  @moduledoc false
+  def select(_resource, context) do
+    case Map.get(context, :source_context, %{}) do
+      %{test_vault: :alt} -> AshCloak.Test.AltVault
+      _ -> AshCloak.Test.Vault
+    end
+  end
+end
+
+defmodule AshCloak.Test.ResourceWithSelector do
+  @moduledoc false
+
+  use Ash.Resource,
+    domain: AshCloak.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshCloak]
+
+  ets do
+    private?(true)
+  end
+
+  actions do
+    defaults([:read, :destroy, create: [:encrypted], update: [:encrypted]])
+  end
+
+  cloak do
+    vault(AshCloak.Test.Vault)
+    attributes([:encrypted])
+    vault_selector({AshCloak.Test.VaultSelector, :select, []})
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:encrypted, :integer, public?: true)
+  end
+end

--- a/test/support/resource_with_selector.ex
+++ b/test/support/resource_with_selector.ex
@@ -4,6 +4,8 @@
 
 defmodule AshCloak.Test.VaultSelector do
   @moduledoc false
+  def select(_resource, nil), do: AshCloak.Test.Vault
+
   def select(_resource, context) do
     case Map.get(context, :source_context, %{}) do
       %{test_vault: :alt} -> AshCloak.Test.AltVault
@@ -29,9 +31,8 @@ defmodule AshCloak.Test.ResourceWithSelector do
   end
 
   cloak do
-    vault(AshCloak.Test.Vault)
+    vault({AshCloak.Test.VaultSelector, :select, []})
     attributes([:encrypted])
-    vault_selector({AshCloak.Test.VaultSelector, :select, []})
   end
 
   attributes do

--- a/test/support/vault.ex
+++ b/test/support/vault.ex
@@ -8,3 +8,10 @@ defmodule AshCloak.Test.Vault do
 
   def decrypt!("encrypted " <> value), do: value
 end
+
+defmodule AshCloak.Test.AltVault do
+  @moduledoc false
+  def encrypt!(value) when is_binary(value), do: "alt_encrypted #{value}"
+
+  def decrypt!("alt_encrypted " <> value), do: value
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

I have a use case where I need to use a different vault per tenant. This PR introduces a `vault_selector` option that accepts a `fun/2` or MFA that resolves which vault to use based on the context given to the action. Falls back to the default vault.