### PR TITLE
fix: encrypt embedded via storage representation

### DIFF
--- a/lib/ash_cloak.ex
+++ b/lib/ash_cloak.ex
@@ -81,18 +81,54 @@ defmodule AshCloak do
   end
 
   @doc false
-  def do_encrypt(resource, value, context \\ nil) do
+  def do_encrypt(resource, field, value, context \\ nil) do
     vault = resolve_vault(resource, context)
 
     encrypted =
-      value
-      |> :erlang.term_to_binary()
+      resource
+      |> serialize(field, value)
       |> vault.encrypt!()
 
     if embedded_binary_handles_encoding?(resource) do
       encrypted
     else
       Base.encode64(encrypted)
+    end
+  end
+
+  # Serialize a value for encryption.
+  #
+  # For types whose serializable representation differs from their in-memory value —
+  # embedded resources, unions, and arrays of them — we encrypt that representation
+  # (`Ash.Type.dump_to_embedded/3`, which is built to produce a plain serializable
+  # structure and so never contains structs) tagged with `:__ash_cloak__`, so reads can
+  # restore it via `Ash.Type.cast_from_embedded/3`. That gives encrypted embedded/union
+  # attributes the same schema-evolution semantics as unencrypted ones, instead of
+  # serializing the raw struct (module tag and internal fields included).
+  #
+  # For every other type the serializable representation is identical to the value, so
+  # we keep the original untagged `term_to_binary/1` format and stay byte-compatible
+  # with data written by earlier versions.
+  #
+  # The `:__ash_cloak__` sentinel distinguishes new payloads from legacy ones on read.
+  # A legacy value is only mistaken for one if it is literally `{:__ash_cloak__, _}` —
+  # effectively impossible, since that atom is internal to this library and `:term`
+  # types (the only ones that could hold such a tuple) dump to themselves and are never
+  # tagged here.
+  defp serialize(resource, field, value) do
+    %{type: type, constraints: constraints} = Ash.Resource.Info.calculation(resource, field)
+
+    case Ash.Type.dump_to_embedded(type, value, constraints) do
+      {:ok, dumped} when dumped !== value ->
+        :erlang.term_to_binary({:__ash_cloak__, dumped})
+
+      {:ok, _dumped} ->
+        :erlang.term_to_binary(value)
+
+      other ->
+        raise ArgumentError,
+              "AshCloak could not dump #{inspect(field)} on #{inspect(resource)} to its " <>
+                "embedded representation for encryption: #{inspect(other)}"
     end
   end
 
@@ -104,7 +140,7 @@ defmodule AshCloak do
   end
 
   defp do_encrypt_and_set(changeset, key, value, context) do
-    encrypted_value = do_encrypt(changeset.resource, value, context)
+    encrypted_value = do_encrypt(changeset.resource, key, value, context)
     encryption_target = String.to_existing_atom("encrypted_#{key}")
 
     changeset

--- a/lib/ash_cloak/calculations/decrypt.ex
+++ b/lib/ash_cloak/calculations/decrypt.ex
@@ -12,6 +12,7 @@ defmodule AshCloak.Calculations.Decrypt do
     vault = AshCloak.resolve_vault(resource, context)
     plain_field = opts[:plain_field]
     skip_base64? = AshCloak.embedded_binary_handles_encoding?(resource)
+    %{type: type, constraints: constraints} = Ash.Resource.Info.calculation(resource, plain_field)
 
     case approve_decrypt(resource, records, plain_field, context) do
       :ok ->
@@ -27,6 +28,7 @@ defmodule AshCloak.Calculations.Decrypt do
               |> maybe_decode64(skip_base64?)
               |> vault.decrypt!()
               |> Ash.Helpers.non_executable_binary_to_term()
+              |> deserialize(type, constraints)
           end
         end)
 
@@ -36,6 +38,24 @@ defmodule AshCloak.Calculations.Decrypt do
   end
 
   def calculate([], _, _), do: []
+
+  # Values written after the serialization change are tagged and restored via
+  # `Ash.Type.cast_from_embedded/3`. Values written before it — and scalar values, which
+  # were never tagged — are the raw term and are returned as-is, keeping existing
+  # encrypted data readable.
+  defp deserialize({:__ash_cloak__, dumped}, type, constraints) do
+    case Ash.Type.cast_from_embedded(type, dumped, constraints) do
+      {:ok, value} ->
+        value
+
+      other ->
+        raise ArgumentError,
+              "AshCloak could not load the stored value for #{inspect(type)} via " <>
+                "cast_from_embedded/3: #{inspect(other)}"
+    end
+  end
+
+  defp deserialize(legacy_value, _type, _constraints), do: legacy_value
 
   defp maybe_decode64(value, true), do: value
   defp maybe_decode64(value, false), do: Base.decode64!(value)

--- a/lib/ash_cloak/changes/encrypt.ex
+++ b/lib/ash_cloak/changes/encrypt.ex
@@ -32,7 +32,10 @@ defmodule AshCloak.Changes.Encrypt do
         encryption_target = String.to_existing_atom("encrypted_#{attribute}")
 
         {:atomic,
-         %{encryption_target => AshCloak.do_encrypt(changeset.resource, value, current_context)}}
+         %{
+           encryption_target =>
+             AshCloak.do_encrypt(changeset.resource, attribute, value, current_context)
+         }}
 
       :error ->
         {:ok, changeset}

--- a/lib/ash_cloak/transformers/set_up_encryption.ex
+++ b/lib/ash_cloak/transformers/set_up_encryption.ex
@@ -95,7 +95,12 @@ defmodule AshCloak.Transformers.SetupEncryption do
       opts =
         case action.type do
           :create ->
-            [allow_nil?: attr.allow_nil?, constraints: attr.constraints, default: attr.default, sensitive?: attr.sensitive?]
+            [
+              allow_nil?: attr.allow_nil?,
+              constraints: attr.constraints,
+              default: attr.default,
+              sensitive?: attr.sensitive?
+            ]
 
           _ ->
             [constraints: attr.constraints, sensitive?: attr.sensitive?]

--- a/test/ash_cloak_test.exs
+++ b/test/ash_cloak_test.exs
@@ -10,7 +10,7 @@ defmodule AshCloakTest do
 
   defp decode(value) do
     "encrypted " <> value = Base.decode64!(value)
-    :erlang.binary_to_term(value)
+    Ash.Helpers.non_executable_binary_to_term(value)
   end
 
   test "it encrypts the input values" do
@@ -246,7 +246,7 @@ defmodule AshCloakTest do
     # value is passed through cast_from_embedded on read, which base64-decodes
     # once. Without the fix, AshCloak would then try to base64-decode the raw
     # ciphertext and crash.
-    encrypted_b64 = AshCloak.do_encrypt(AshCloak.Test.EmbeddedResource, 99)
+    encrypted_b64 = AshCloak.do_encrypt(AshCloak.Test.EmbeddedResource, :encrypted, 99)
 
     # Apply what Ash 3.26's cast_from_embedded does to that stored value.
     {:ok, after_cast} = Ash.Type.Binary.cast_from_embedded(encrypted_b64, [])
@@ -262,7 +262,7 @@ defmodule AshCloakTest do
   end
 
   test "round-trips new writes on Ash 3.26+ embedded resources" do
-    encrypted_b64_or_raw = AshCloak.do_encrypt(AshCloak.Test.EmbeddedResource, 42)
+    encrypted_b64_or_raw = AshCloak.do_encrypt(AshCloak.Test.EmbeddedResource, :encrypted, 42)
 
     # Simulate the new write/read cycle: AshCloak produces a value, Ash's
     # dump_to_embedded base64-encodes it for storage, then cast_from_embedded

--- a/test/embedded_serialization_test.exs
+++ b/test/embedded_serialization_test.exs
@@ -4,67 +4,77 @@
 
 defmodule AshCloak.EmbeddedSerializationTest do
   @moduledoc """
-  Reproduces how ash_cloak serializes an encrypted attribute whose type is an
-  embedded resource.
+  An encrypted attribute whose type is an embedded resource (or a union of embedded
+  resources) is serialized through the type's embedded representation
+  (`Ash.Type.dump_to_embedded/3`) and restored via `Ash.Type.cast_from_embedded/3`, so
+  it gets the same schema-evolution semantics as an unencrypted embedded attribute.
 
-  The encryption path serializes the in-memory Elixir struct via
-  `:erlang.term_to_binary/1`, instead of going through the type's storage
-  representation (`dump_to_native/2`). On read it `binary_to_term`s the struct
-  straight back, instead of `cast_stored/2`.
+  Data written before this change (the raw struct, `term_to_binary`'d with no tag)
+  must keep decrypting.
   """
   use ExUnit.Case
 
-  require Ash.Query
-
-  alias AshCloak.Test.{EmbeddedProfile, ResourceWithEmbedded}
+  alias AshCloak.Test.{EmbeddedProfile, ResourceWithEmbedded, ResourceWithUnion}
 
   # Mirrors the AshCloak.Test.Vault format: "encrypted " <> term_to_binary, base64-encoded.
   defp decode(value) do
-    "encrypted " <> value = Base.decode64!(value)
-    Ash.Helpers.non_executable_binary_to_term(value)
+    "encrypted " <> binary = Base.decode64!(value)
+    Ash.Helpers.non_executable_binary_to_term(binary)
   end
 
-  test "the stored ciphertext is the raw struct, not the type's storage representation" do
+  defp embedded_representation(resource, field, value) do
+    %{type: type, constraints: constraints} = Ash.Resource.Info.calculation(resource, field)
+    {:ok, dumped} = Ash.Type.dump_to_embedded(type, value, constraints)
+    dumped
+  end
+
+  test "an embedded attribute stores its storage representation, not the raw struct" do
     record =
       ResourceWithEmbedded
       |> Ash.Changeset.for_create(:create, %{profile: %{nickname: "neo", age: 30}})
       |> Ash.create!()
 
-    stored = decode(record.encrypted_profile)
+    assert {:__ash_cloak__, dumped} = decode(record.encrypted_profile)
 
-    # What ash_cloak actually persists: the full in-memory struct, __struct__ tag and all.
-    assert is_struct(stored, EmbeddedProfile)
-    assert %EmbeddedProfile{nickname: "neo", age: 30} = stored
+    # The stored payload is the struct-free embedded representation: no __struct__ tag,
+    # and no internal fields that dump_to_embedded/3 strips.
+    refute is_struct(dumped)
+    assert is_map(dumped)
+    refute Map.has_key?(dumped, :__meta__)
+    assert dumped == embedded_representation(ResourceWithEmbedded, :profile, record.profile)
 
-    # Internal fields that dump_to_native/2 would strip leak into the payload.
-    assert Map.has_key?(stored, :__meta__)
-
-    # What an unencrypted embedded attribute would persist (the jsonb the data layer sees):
-    # a plain, struct-free map produced by the type's dump_to_native/2.
-    {:ok, storage_representation} = Ash.Type.dump_to_native(EmbeddedProfile, stored, [])
-
-    refute is_struct(storage_representation)
-    assert is_map(storage_representation)
-    refute Map.has_key?(storage_representation, :__meta__)
-
-    # The two diverge: encryption bypasses the storage representation entirely.
-    refute stored == storage_representation
+    # It round-trips back through cast_from_embedded/3 into a clean struct.
+    assert %EmbeddedProfile{nickname: "neo", age: 30} = record.profile
   end
 
-  test "decryption restores the struct via binary_to_term, bypassing cast_stored/2" do
+  test "a union-of-embedded attribute stores its storage representation" do
     record =
-      ResourceWithEmbedded
-      |> Ash.Changeset.for_create(:create, %{profile: %{nickname: "trinity", age: 28}})
+      ResourceWithUnion
+      |> Ash.Changeset.for_create(:create, %{thing: %{nickname: "trinity", age: 28}})
       |> Ash.create!()
 
-    # Round-trips fine *today* because the same struct is binary_to_term'd back.
-    assert %EmbeddedProfile{nickname: "trinity", age: 28} = record.profile
+    assert {:__ash_cloak__, dumped} = decode(record.encrypted_thing)
 
-    # But the value never passed through cast_stored/2: it is the exact same term that
-    # was term_to_binary'd on write. The module name and struct shape are baked into the
-    # blob, so renaming/removing the embedded module, or relying on cast_stored to absorb
-    # a schema change, would not be reflected when reading old ciphertext.
-    stored = decode(record.encrypted_profile)
-    assert stored == record.profile
+    refute is_struct(dumped)
+    assert dumped == embedded_representation(ResourceWithUnion, :thing, record.thing)
+
+    assert %Ash.Union{type: :profile, value: %EmbeddedProfile{nickname: "trinity", age: 28}} =
+             record.thing
+  end
+
+  test "decrypts pre-change data written in the old raw-term format" do
+    # A row written before the storage-representation change: the raw cast struct,
+    # term_to_binary'd, encrypted, base64-encoded — with no :__ash_cloak__ tag.
+    old_blob =
+      %EmbeddedProfile{nickname: "neo", age: 30}
+      |> :erlang.term_to_binary()
+      |> AshCloak.Test.Vault.encrypt!()
+      |> Base.encode64()
+
+    record = %ResourceWithEmbedded{id: Ash.UUID.generate(), encrypted_profile: old_blob}
+
+    loaded = Ash.load!(record, [:profile], domain: AshCloak.Test.Domain)
+
+    assert %EmbeddedProfile{nickname: "neo", age: 30} = loaded.profile
   end
 end

--- a/test/embedded_serialization_test.exs
+++ b/test/embedded_serialization_test.exs
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2024 ash_cloak contributors <https://github.com/ash-project/ash_cloak/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshCloak.EmbeddedSerializationTest do
+  @moduledoc """
+  Reproduces how ash_cloak serializes an encrypted attribute whose type is an
+  embedded resource.
+
+  The encryption path serializes the in-memory Elixir struct via
+  `:erlang.term_to_binary/1`, instead of going through the type's storage
+  representation (`dump_to_native/2`). On read it `binary_to_term`s the struct
+  straight back, instead of `cast_stored/2`.
+  """
+  use ExUnit.Case
+
+  require Ash.Query
+
+  alias AshCloak.Test.{EmbeddedProfile, ResourceWithEmbedded}
+
+  # Mirrors the AshCloak.Test.Vault format: "encrypted " <> term_to_binary, base64-encoded.
+  defp decode(value) do
+    "encrypted " <> value = Base.decode64!(value)
+    Ash.Helpers.non_executable_binary_to_term(value)
+  end
+
+  test "the stored ciphertext is the raw struct, not the type's storage representation" do
+    record =
+      ResourceWithEmbedded
+      |> Ash.Changeset.for_create(:create, %{profile: %{nickname: "neo", age: 30}})
+      |> Ash.create!()
+
+    stored = decode(record.encrypted_profile)
+
+    # What ash_cloak actually persists: the full in-memory struct, __struct__ tag and all.
+    assert is_struct(stored, EmbeddedProfile)
+    assert %EmbeddedProfile{nickname: "neo", age: 30} = stored
+
+    # Internal fields that dump_to_native/2 would strip leak into the payload.
+    assert Map.has_key?(stored, :__meta__)
+
+    # What an unencrypted embedded attribute would persist (the jsonb the data layer sees):
+    # a plain, struct-free map produced by the type's dump_to_native/2.
+    {:ok, storage_representation} = Ash.Type.dump_to_native(EmbeddedProfile, stored, [])
+
+    refute is_struct(storage_representation)
+    assert is_map(storage_representation)
+    refute Map.has_key?(storage_representation, :__meta__)
+
+    # The two diverge: encryption bypasses the storage representation entirely.
+    refute stored == storage_representation
+  end
+
+  test "decryption restores the struct via binary_to_term, bypassing cast_stored/2" do
+    record =
+      ResourceWithEmbedded
+      |> Ash.Changeset.for_create(:create, %{profile: %{nickname: "trinity", age: 28}})
+      |> Ash.create!()
+
+    # Round-trips fine *today* because the same struct is binary_to_term'd back.
+    assert %EmbeddedProfile{nickname: "trinity", age: 28} = record.profile
+
+    # But the value never passed through cast_stored/2: it is the exact same term that
+    # was term_to_binary'd on write. The module name and struct shape are baked into the
+    # blob, so renaming/removing the embedded module, or relying on cast_stored to absorb
+    # a schema change, would not be reflected when reading old ciphertext.
+    stored = decode(record.encrypted_profile)
+    assert stored == record.profile
+  end
+end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -10,5 +10,6 @@ defmodule AshCloak.Test.Domain do
     resource(AshCloak.Test.Resource)
     resource(AshCloak.Test.ResourceWithSelector)
     resource(AshCloak.Test.ContainerResource)
+    resource(AshCloak.Test.ResourceWithEmbedded)
   end
 end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -11,5 +11,6 @@ defmodule AshCloak.Test.Domain do
     resource(AshCloak.Test.ResourceWithSelector)
     resource(AshCloak.Test.ContainerResource)
     resource(AshCloak.Test.ResourceWithEmbedded)
+    resource(AshCloak.Test.ResourceWithUnion)
   end
 end

--- a/test/support/embedded_profile.ex
+++ b/test/support/embedded_profile.ex
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2024 ash_cloak contributors <https://github.com/ash-project/ash_cloak/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshCloak.Test.EmbeddedProfile do
+  @moduledoc """
+  A plain embedded resource used as the *type* of an encrypted attribute.
+
+  It is intentionally not encrypted itself — the point is to observe how
+  ash_cloak serializes a value of this type when that value lives in an
+  encrypted attribute on another resource.
+  """
+
+  use Ash.Resource, data_layer: :embedded
+
+  actions do
+    defaults([:read, :destroy, create: [:nickname, :age], update: [:nickname, :age]])
+  end
+
+  attributes do
+    attribute(:nickname, :string, public?: true)
+    attribute(:age, :integer, public?: true)
+  end
+end

--- a/test/support/resource_with_embedded.ex
+++ b/test/support/resource_with_embedded.ex
@@ -6,9 +6,9 @@ defmodule AshCloak.Test.ResourceWithEmbedded do
   @moduledoc """
   A resource with an encrypted attribute whose type is an embedded resource.
 
-  Used to reproduce how ash_cloak serializes embedded values: via
-  `:erlang.term_to_binary/1` on the in-memory struct, rather than through the
-  type's storage representation (`dump_to_native/2`).
+  Used by tests to assert embedded values are encrypted via their embedded
+  representation (`Ash.Type.dump_to_embedded/3`) and restored via
+  `Ash.Type.cast_from_embedded/3`.
   """
 
   use Ash.Resource,

--- a/test/support/resource_with_embedded.ex
+++ b/test/support/resource_with_embedded.ex
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2024 ash_cloak contributors <https://github.com/ash-project/ash_cloak/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshCloak.Test.ResourceWithEmbedded do
+  @moduledoc """
+  A resource with an encrypted attribute whose type is an embedded resource.
+
+  Used to reproduce how ash_cloak serializes embedded values: via
+  `:erlang.term_to_binary/1` on the in-memory struct, rather than through the
+  type's storage representation (`dump_to_native/2`).
+  """
+
+  use Ash.Resource,
+    domain: AshCloak.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshCloak]
+
+  ets do
+    private?(true)
+  end
+
+  actions do
+    defaults([:read, :destroy, create: [:profile], update: [:profile]])
+  end
+
+  cloak do
+    vault(AshCloak.Test.Vault)
+    attributes([:profile])
+    decrypt_by_default([:profile])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:profile, AshCloak.Test.EmbeddedProfile, public?: true)
+  end
+end

--- a/test/support/resource_with_union.ex
+++ b/test/support/resource_with_union.ex
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2024 ash_cloak contributors <https://github.com/ash-project/ash_cloak/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshCloak.Test.ResourceWithUnion do
+  @moduledoc """
+  A resource with an encrypted attribute whose type is a union that includes an
+  embedded resource. Exercises that union values are encrypted via their storage
+  representation rather than the raw `%Ash.Union{}`/embedded struct.
+  """
+
+  use Ash.Resource,
+    domain: AshCloak.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshCloak]
+
+  ets do
+    private?(true)
+  end
+
+  actions do
+    defaults([:read, :destroy, create: [:thing], update: [:thing]])
+  end
+
+  cloak do
+    vault(AshCloak.Test.Vault)
+    attributes([:thing])
+    decrypt_by_default([:thing])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute(:thing, :union,
+      public?: true,
+      constraints: [
+        types: [
+          profile: [type: AshCloak.Test.EmbeddedProfile],
+          note: [type: :string]
+        ]
+      ]
+    )
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies


Resolves #146

## Problem

Encrypting an attribute whose type is an embedded resource (or a union of embedded resources) serialized the raw in-memory struct via `:erlang.term_to_binary/1` instead of the type's storage representation, and restored it with `binary_to_term` instead of `cast_stored/2`. Unlike an unencrypted embedded attribute, that meant schema changes weren't absorbed via `cast_stored/2`, the embedded module name was baked into the ciphertext (renames broke decryption), and internal fields like `__meta__` leaked into the payload. Scalars were unaffected.

## Fix

Encrypt the storage representation (`dump_to_native/2`) and restore it via `cast_stored/2`:

```elixir
# write
{:__ash_cloak__, Ash.Type.dump_to_native(type, value, constraints)}
|> :erlang.term_to_binary()
|> vault.encrypt!()

# read
case Ash.Helpers.non_executable_binary_to_term(decrypted) do
  {:__ash_cloak__, native} -> Ash.Type.cast_stored(type, native, constraints)
  legacy                   -> legacy
end
```

- **Backwards compatible:** existing columns are untagged `term_to_binary(value)` and fall through to `legacy`, so old data keeps decrypting. A value is only re-encoded when its storage representation differs from the in-memory value (embedded/union/array), so scalars/maps keep their current on-disk bytes.
- `type`/`constraints` are recovered at runtime from the registered calculation, not stored in the payload — keeps the module name out of the ciphertext and casts old data through the *current* type.
- Sentinel is `:__ash_cloak__` (the `__struct__`/`__meta__` convention) to avoid colliding with user data; decryption uses the `:safe` `non_executable_binary_to_term/1`.