### PR TITLE
feat: add encrypt_nil? option to store nil as SQL NULL

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -2,7 +2,13 @@
 #
 # SPDX-License-Identifier: MIT
 
-spark_locals_without_parens = [attributes: 1, decrypt_by_default: 1, on_decrypt: 1, vault: 1]
+spark_locals_without_parens = [
+  attributes: 1,
+  decrypt_by_default: 1,
+  encrypt_nil?: 1,
+  on_decrypt: 1,
+  vault: 1
+]
 
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],

--- a/documentation/dsls/DSL-AshCloak.md
+++ b/documentation/dsls/DSL-AshCloak.md
@@ -24,6 +24,7 @@ Encrypt attributes of a resource
 | [`attributes`](#cloak-attributes){: #cloak-attributes } | `atom \| list(atom)` | `[]` | The attribute or attributes to encrypt. The attribute will be renamed to `encrypted_{attribute}`, and a calculation with the same name will be added. |
 | [`decrypt_by_default`](#cloak-decrypt_by_default){: #cloak-decrypt_by_default } | `atom \| list(atom)` | `[]` | A list of attributes that should be decrypted (their calculation should be loaded) by default. |
 | [`on_decrypt`](#cloak-on_decrypt){: #cloak-on_decrypt } | `(any, any, any, any -> any) \| mfa` |  | A function to call when decrypting any value. Takes the resource, field, records, and calculation context. Must return `:ok` or `{:error, error}` |
+| [`encrypt_nil?`](#cloak-encrypt_nil?){: #cloak-encrypt_nil? } | `boolean` | `true` | When `false`, a `nil` value for an encrypted attribute is stored as SQL NULL in the backing `encrypted_*` column instead of being encrypted. This keeps `IS NOT NULL` queries meaningful for nullable attributes. Defaults to `true`, which encrypts `nil` and stores a non-null ciphertext, preserving the original behavior. |
 
 
 

--- a/documentation/topics/how-does-ash-cloak-work.md
+++ b/documentation/topics/how-does-ash-cloak-work.md
@@ -24,6 +24,12 @@ This `change` also deletes the argument from the arguments list and from the par
 
 Finally, it add a `preparation` and a `change` that will automatically load the corresponding calculations for any attribute in the `decrypt_by_default` list.
 
+## Nil handling
+
+By default (`encrypt_nil?: true`), a `nil` value is encrypted like any other value, so the backing `encrypted_*` column holds a non-null ciphertext. This hides whether the attribute has a value at all, but means `encrypted_<name> IS NOT NULL` is always true.
+
+Set `encrypt_nil?: false` to store `nil` as SQL `NULL` in the backing column instead. This keeps `IS NOT NULL` queries meaningful for nullable attributes — useful for cleanup, backfill, and debugging without decrypting every row. On read, the decrypt calculation maps a `NULL` backing value back to `nil`, so the round-trip is unchanged. This option is intended for nullable attributes; assigning `nil` to a non-nullable attribute (for example, via an update) will surface the usual required-value error.
+
 ## The result
 
 The cloaked attribute will now seamlessly encrypt when writing and decrypt on request.

--- a/lib/ash_cloak.ex
+++ b/lib/ash_cloak.ex
@@ -39,6 +39,15 @@ defmodule AshCloak do
         type: {:or, [{:fun, 4}, :mfa]},
         doc:
           "A function to call when decrypting any value. Takes the resource, field, records, and calculation context. Must return `:ok` or `{:error, error}`"
+      ],
+      encrypt_nil?: [
+        type: :boolean,
+        default: true,
+        doc:
+          "When `false`, a `nil` value for an encrypted attribute is stored as SQL NULL in the " <>
+            "backing `encrypted_*` column instead of being encrypted. This keeps `IS NOT NULL` " <>
+            "queries meaningful for nullable attributes. Defaults to `true`, which encrypts `nil` " <>
+            "and stores a non-null ciphertext, preserving the original behavior."
       ]
     ]
   }
@@ -82,17 +91,23 @@ defmodule AshCloak do
 
   @doc false
   def do_encrypt(resource, field, value, context \\ nil) do
-    vault = resolve_vault(resource, context)
-
-    encrypted =
-      resource
-      |> serialize(field, value)
-      |> vault.encrypt!()
-
-    if embedded_binary_handles_encoding?(resource) do
-      encrypted
+    if is_nil(value) and not AshCloak.Info.cloak_encrypt_nil?(resource) do
+      # Storing SQL NULL keeps `IS NOT NULL` queries meaningful for nullable attributes.
+      # On read the decrypt calculation already maps a nil backing value back to nil.
+      nil
     else
-      Base.encode64(encrypted)
+      vault = resolve_vault(resource, context)
+
+      encrypted =
+        resource
+        |> serialize(field, value)
+        |> vault.encrypt!()
+
+      if embedded_binary_handles_encoding?(resource) do
+        encrypted
+      else
+        Base.encode64(encrypted)
+      end
     end
   end
 

--- a/test/ash_cloak/encrypt_nil_test.exs
+++ b/test/ash_cloak/encrypt_nil_test.exs
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2024 ash_cloak contributors <https://github.com/ash-project/ash_cloak/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshCloak.EncryptNilTest do
+  use ExUnit.Case
+
+  require Ash.Query
+
+  defp decode(value) do
+    "encrypted " <> value = Base.decode64!(value)
+    Ash.Helpers.non_executable_binary_to_term(value)
+  end
+
+  describe "encrypt_nil? introspection" do
+    test "defaults to true, preserving the original behavior" do
+      assert AshCloak.Info.cloak_encrypt_nil?(AshCloak.Test.Resource) == true
+    end
+
+    test "is false when configured" do
+      assert AshCloak.Info.cloak_encrypt_nil?(AshCloak.Test.NilResource) == false
+    end
+  end
+
+  describe "encrypt_nil? true (default)" do
+    test "encrypts nil into a non-null ciphertext" do
+      created =
+        AshCloak.Test.Resource
+        |> Ash.Changeset.for_create(:create, %{encrypted: nil})
+        |> Ash.create!()
+
+      # a nil value is still encrypted, so the backing column is NOT NULL ...
+      assert created.encrypted_encrypted != nil
+      # ... and decrypts back to nil
+      assert decode(created.encrypted_encrypted) == nil
+    end
+
+    test "do_encrypt/4 encrypts a nil value" do
+      assert AshCloak.do_encrypt(AshCloak.Test.Resource, :encrypted, nil) != nil
+    end
+  end
+
+  describe "encrypt_nil? false" do
+    test "stores nil as SQL NULL on create and round-trips back to nil" do
+      created =
+        AshCloak.Test.NilResource
+        |> Ash.Changeset.for_create(:create, %{encrypted: nil})
+        |> Ash.create!()
+
+      # the backing column is SQL NULL, so `IS NOT NULL` stays meaningful
+      assert created.encrypted_encrypted == nil
+
+      # and the decrypt calculation maps the NULL back to nil
+      loaded = Ash.load!(created, [:encrypted])
+      assert loaded.encrypted == nil
+    end
+
+    test "still encrypts a non-nil value" do
+      created =
+        AshCloak.Test.NilResource
+        |> Ash.Changeset.for_create(:create, %{encrypted: 12})
+        |> Ash.create!()
+
+      assert decode(created.encrypted_encrypted) == 12
+      assert Ash.load!(created, [:encrypted]).encrypted == 12
+    end
+
+    test "clears the backing column to NULL on update" do
+      created =
+        AshCloak.Test.NilResource
+        |> Ash.Changeset.for_create(:create, %{encrypted: 12})
+        |> Ash.create!()
+
+      assert created.encrypted_encrypted != nil
+
+      updated =
+        created
+        |> Ash.Changeset.for_update(:update, %{encrypted: nil})
+        |> Ash.update!()
+
+      assert updated.encrypted_encrypted == nil
+      assert Ash.load!(updated, [:encrypted]).encrypted == nil
+    end
+
+    test "clears the backing column to NULL on atomic/bulk update" do
+      created =
+        AshCloak.Test.NilResource
+        |> Ash.Changeset.for_create(:create, %{encrypted: 12})
+        |> Ash.create!()
+
+      assert %Ash.BulkResult{records: [updated]} =
+               AshCloak.Test.NilResource
+               |> Ash.Query.filter(id == ^created.id)
+               |> Ash.bulk_update!(:update, %{encrypted: nil}, return_records?: true)
+
+      assert updated.encrypted_encrypted == nil
+      assert Ash.load!(updated, [:encrypted]).encrypted == nil
+    end
+
+    test "do_encrypt/4 returns nil for a nil value but encrypts other values" do
+      assert AshCloak.do_encrypt(AshCloak.Test.NilResource, :encrypted, nil) == nil
+      assert AshCloak.do_encrypt(AshCloak.Test.NilResource, :encrypted, 5) != nil
+    end
+  end
+end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -8,6 +8,7 @@ defmodule AshCloak.Test.Domain do
 
   resources do
     resource(AshCloak.Test.Resource)
+    resource(AshCloak.Test.NilResource)
     resource(AshCloak.Test.ResourceWithSelector)
     resource(AshCloak.Test.ContainerResource)
     resource(AshCloak.Test.ResourceWithEmbedded)

--- a/test/support/nil_resource.ex
+++ b/test/support/nil_resource.ex
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2024 ash_cloak contributors <https://github.com/ash-project/ash_cloak/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshCloak.Test.NilResource do
+  @moduledoc false
+
+  use Ash.Resource,
+    domain: AshCloak.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshCloak]
+
+  ets do
+    private?(true)
+  end
+
+  @attributes [:encrypted, :not_encrypted]
+  actions do
+    defaults([:read, :destroy, create: @attributes, update: @attributes])
+  end
+
+  cloak do
+    vault(AshCloak.Test.Vault)
+    attributes([:encrypted])
+    encrypt_nil?(false)
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:not_encrypted, :string)
+    # nullable (allow_nil? defaults to true) so a nil value can be stored as SQL NULL
+    attribute(:encrypted, :integer, public?: true)
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

Adds an opt-in `encrypt_nil?` option to the `cloak` section. When set to `false`, a `nil` value is stored as SQL `NULL` in the backing `encrypted_*` column instead of being encrypted.

```elixir
cloak do
  vault MyApp.Vault
  attributes [:indiv_ssn]
  encrypt_nil? false
end
```

## Motivation

For nullable encrypted fields, encrypting `nil` makes storage hard to reason about: `IS NOT NULL` no longer means "has a real value", cleanup/backfill queries can't tell a real value from an encrypted `nil` without decrypting every
row, and clearing a field requires referencing the internal `encrypted_#{field}` column. With `encrypt_nil? false`, clearing a field is just passing `nil`.

### Why section-level instead of per-attribute?

Per-attribute (`attribute :indiv_ssn, encrypt_nil?: false`) would be nicer for mixed resources, but `attributes` is currently a flat `{:wrap_list, :atom}` list. Per-attribute options would require turning it into Spark entities, a
breaking DSL change for every existing user. The boolean is forward-compatible: its type can later be widened (e.g. `boolean | list(atom)`) to add per-attribute control without breaking the current syntax.